### PR TITLE
Release 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "option",
-    "version": "0.2.2",
+    "version": "1.0.0",
     "author": "Michael Williamson <mike@zwobble.org>",
     "description": "The option type, also known as the maybe type, for JavaScript",
     "license": "BSD",


### PR DESCRIPTION
The package already has users, they already care about backwards compatibility, and if we break BC, we bump the major version. Semver at its best.
Lately many packages began moving to 1.0.0-based versioning.
npm by default starts packages at 1.0.0.
Pre-1 versions are not even defined in semver the way everybody thinks they are.
Strongly recommend. 
