### PR TITLE
Add filter method

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,12 +48,12 @@ Conventionally used when `func` returns another option.
 * `some(value).flatMap(func)` returns `func(value)`
 * `none.flatMap(func)` returns `none`
 
-### filter(func)
+### filter(*predicate*)
 
-* `some(value).filter(func)` returns:
-  * `some(value)` if `func(value) === true`
-  * `none` if `func(value) === false`
-* `none.filter(func)` returns `none`
+* `some(value).filter(predicate)` returns:
+  * `some(value)` if `predicate(value) === true`
+  * `none` if `predicate(value) === false`
+* `none.filter(predicate)` returns `none`
 
 ### toArray()
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ Conventionally used when `func` returns another option.
 * `some(value).flatMap(func)` returns `func(value)`
 * `none.flatMap(func)` returns `none`
 
+### filter(func)
+
+* `some(value).filter(func)` returns:
+  * `some(value)` if `func(value) === true`
+  * `none` if `func(value) === false`
+* `none.filter(func)` returns `none`
 
 ### toArray()
 

--- a/index.js
+++ b/index.js
@@ -14,6 +14,9 @@ exports.none = Object.create({
     flatMap: function() {
         return exports.none;
     },
+    filter: function() {
+        return exports.none;
+    },
     toArray: function() {
         return [];
     },
@@ -55,6 +58,12 @@ Some.prototype.map = function(func) {
 
 Some.prototype.flatMap = function(func) {
     return func(this._value);
+};
+
+Some.prototype.filter = function(f) {
+    return this.flatMap(function(x) {
+        return f(x) ? exports.some(x) : exports.none;
+    });
 };
 
 Some.prototype.toArray = function() {

--- a/index.js
+++ b/index.js
@@ -60,10 +60,8 @@ Some.prototype.flatMap = function(func) {
     return func(this._value);
 };
 
-Some.prototype.filter = function(f) {
-    return this.flatMap(function(x) {
-        return f(x) ? exports.some(x) : exports.none;
-    });
+Some.prototype.filter = function(predicate) {
+    return predicate(this._value) ? this : exports.none;
 };
 
 Some.prototype.toArray = function() {

--- a/test/options.test.js
+++ b/test/options.test.js
@@ -141,3 +141,34 @@ exports.callingValueOnSomeReturnsValue = function(test) {
     test.deepEqual(4, options.some(4).value());
     test.done();
 };
+
+exports.filteringNoneReturnsNone = function(test) {
+    function equals3(x) {
+        return x === 3;
+    }
+
+    test.deepEqual(options.none.filter(equals3), options.none);
+    test.done();
+};
+
+exports.filteringSomeReturnsIdentityIfPredicateIsTrue = function(test) {
+    var some3 = options.some(3);
+
+    function equals3(x) {
+        return x === 3;
+    }
+
+    test.deepEqual(some3.filter(equals3), some3);
+    test.done();
+};
+
+exports.filteringSomeReturnsNoneIfPredicateIsFalse = function(test) {
+    var some11 = options.some(11);
+
+    function equals3(x) {
+        return x === 3;
+    }
+
+    test.deepEqual(some11.filter(equals3), options.none);
+    test.done();
+};

--- a/test/options.test.js
+++ b/test/options.test.js
@@ -142,7 +142,7 @@ exports.callingValueOnSomeReturnsValue = function(test) {
     test.done();
 };
 
-exports.filteringNoneReturnsNone = function(test) {
+exports["none.filter returns none"] = function(test) {
     function equals3(x) {
         return x === 3;
     }
@@ -151,7 +151,7 @@ exports.filteringNoneReturnsNone = function(test) {
     test.done();
 };
 
-exports.filteringSomeReturnsIdentityIfPredicateIsTrue = function(test) {
+exports["when predicate(value) is true, some(value).filter(predicate) returns some(value)"] = function(test) {
     var some3 = options.some(3);
 
     function equals3(x) {
@@ -162,7 +162,7 @@ exports.filteringSomeReturnsIdentityIfPredicateIsTrue = function(test) {
     test.done();
 };
 
-exports.filteringSomeReturnsNoneIfPredicateIsFalse = function(test) {
+exports["when predicate(value) is false, some(value).filter(predicate) returns none"] = function(test) {
     var some11 = options.some(11);
 
     function equals3(x) {


### PR DESCRIPTION
Scala's Option has a [filter](https://www.scala-lang.org/api/current/scala/Option.html#filter(p:A=>Boolean):Option[A]) method that is useful. I've found myself shimming this method for this library, so thought it might be worth including directly.