### PR TITLE
Prevent Some.map(=> undefined) from returning a Some(undefined)

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ Some.prototype.isSome = function() {
 };
 
 Some.prototype.map = function(func) {
-    return new Some(func(this._value));
+    return exports.fromNullable(func(this._value));
 };
 
 Some.prototype.flatMap = function(func) {

--- a/test/options.test.js
+++ b/test/options.test.js
@@ -172,3 +172,10 @@ exports["when predicate(value) is false, some(value).filter(predicate) returns n
     test.deepEqual(some11.filter(equals3), options.none);
     test.done();
 };
+
+exports.someMapUndefinedIsNone = function(test) {
+    var some = options.some({});
+
+    test.deepEqual(some.map(_ => _.missingProperty), options.none);
+    test.done();
+}


### PR DESCRIPTION
In using this library I encountered the following situation that I think grates against the idea of the Option.

Imagine we are inside an express route and all I want to do is echo back a form parameter:
```
app.get(req, res, () => {
  const name = req.body.name;
  res.send(name);
});
```

In this example the possible places for `undefined` to creep in are `req.body` and `req.body.name`. So I rewrite it to:
```
app.get(req, res, () => {
  const name = option.fromNullable(req.body)
    .map(body => body.name)
    .valueOrElse('John Smith');
  res.send(name);
});
```
I expected that if the `body.name` is undefined then Map would give me a `None`, but instead I get `Some(undefined)`. This feels like it grates against the concept of Option as a thing that prevents undefined from leaking in to your app.

This PR fixes this by running the results of `Some.map` through `Option.fromNullable`.